### PR TITLE
Prepare repo for 2025 usage after unarchival

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,8 @@
+# Required when using Windows and Linux together
+# Otherwise Linux git will think all files are modified
+* text=auto eol=crlf
+
+# Required for running shell scripts in the container
+scripts/* eol=lf
+
 Dockerfile.template linguist-language=Dockerfile

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,1 @@
-# Required when using Windows and Linux together
-# Otherwise Linux git will think all files are modified
-* text=auto eol=crlf
-
-# Required for running shell scripts in the container
-scripts/* eol=lf
+* text=auto eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,3 @@
 
 # Required for running shell scripts in the container
 scripts/* eol=lf
-
-Dockerfile.template linguist-language=Dockerfile

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -17,10 +17,12 @@ jobs:
         include:
           - terragrunt_version: "v0.83.2"
           - tflint_version: "v0.58.1"
+          - alpine_version: "3.22"
     env:
       TERRAFORM_VERSION: ${{ matrix.terraform_version }}
       TERRAGRUNT_VERSION: ${{ matrix.terragrunt_version }}
       TFLINT_VERSION: ${{ matrix.tflint_version }}
+      ALPINE_VERSION: ${{ matrix.alpine_version }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -16,10 +16,12 @@ jobs:
         terraform_version: ["1.12.2", "1.10.5"]
         include:
           - terragrunt_version: "v0.83.2"
+          - tflint_version: "v0.58.1"
     env:
       DOCKER_BUILDKIT: 1
       TERRAFORM_VERSION: ${{ matrix.terraform_version }}
       TERRAGRUNT_VERSION: ${{ matrix.terragrunt_version }}
+      TFLINT_VERSION: ${{ matrix.tflint_version }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,4 +1,4 @@
-name: Build and Publish ForeFlight Terraform image
+name: Build and Publish ForeFlight Terraform Image
 
 on:
   push:

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Build and Publish ForeFlight Terraform image
 
 on:
   push:
@@ -13,10 +13,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        terraform_version: ["1.3.4", "1.3.5"]
+        terraform_version: ["1.12.2", "1.10.5"]
         include:
-          - terragrunt_version: "v0.40.0"
-            awscli_version: "2.9.0"
+          - terragrunt_version: "v0.83.2"
+            awscli_version: "2.27.5"
     env:
       DOCKER_BUILDKIT: 1
       TERRAFORM_VERSION: ${{ matrix.terraform_version }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -16,12 +16,10 @@ jobs:
         terraform_version: ["1.12.2", "1.10.5"]
         include:
           - terragrunt_version: "v0.83.2"
-            awscli_version: "2.27.5"
     env:
       DOCKER_BUILDKIT: 1
       TERRAFORM_VERSION: ${{ matrix.terraform_version }}
       TERRAGRUNT_VERSION: ${{ matrix.terragrunt_version }}
-      AWSCLI_VERSION: ${{ matrix.awscli_version }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -18,7 +18,6 @@ jobs:
           - terragrunt_version: "v0.83.2"
           - tflint_version: "v0.58.1"
     env:
-      DOCKER_BUILDKIT: 1
       TERRAFORM_VERSION: ${{ matrix.terraform_version }}
       TERRAGRUNT_VERSION: ${{ matrix.terragrunt_version }}
       TFLINT_VERSION: ${{ matrix.tflint_version }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,12 +41,11 @@ ARG TARGETARCH
 RUN set -ex \
     && apk add curl unzip \
     && curl -L "https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}/tflint_${TARGETOS}_${TARGETARCH}.zip" -o "tflint.zip" \
-    && unzip tflint.zip\
+    && unzip tflint.zip \
     && mv tflint /usr/local/bin/
 
 FROM alpine:${ALPINE_VERSION}
 
-ARG AWSCLI_VERSION
 ENV TF_PLUGIN_CACHE_DIR=/tmp/terraform
 
 RUN set -ex \
@@ -68,7 +67,7 @@ RUN set -ex \
 COPY --from=terraform-builder /usr/local/bin/terraform /usr/local/bin/terraform
 # Install Terragrunt.
 COPY --from=terragrunt-builder /usr/local/bin/terragrunt /usr/local/bin/terragrunt
-#Install TFLint
+# Install TFLint.
 COPY --from=tflint-builder /usr/local/bin/tflint /usr/local/bin/tflint
 
 ENTRYPOINT ["/usr/local/bin/terraform"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-ARG debian_version=bookworm-slim
+ARG alpine_version=3.22
 
 # We install each tool (e.g., Terraform, Terragrunt, and the AWS CLI) in a
 # separate build stage. This design allows us to install each tool in parallel
 # while preventing a change to one layer from blowing away the cache of
 # subsequent layers.
 # https://docs.docker.com/build/building/multi-stage/
-FROM debian:${debian_version} AS terraform-builder
+FROM alpine:${alpine_version} AS terraform-builder
 
 # These args support multi-platform builds if we decide to produce a linux/arm64
 # variant.
@@ -15,62 +15,45 @@ ARG TARGETOS
 ARG TARGETARCH
 
 RUN set -ex \
-    && apt-get update && apt-get install -y ca-certificates curl unzip --no-install-recommends \
+    && apk add curl unzip \
     && curl "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${TARGETOS}_${TARGETARCH}.zip" -o "terraform.zip" \
     && unzip terraform.zip \
     && mv terraform /usr/local/bin/
 
-FROM debian:${debian_version} AS terragrunt-builder
+FROM alpine:${alpine_version} AS terragrunt-builder
 
 ARG TERRAGRUNT_VERSION
 ARG TARGETOS
 ARG TARGETARCH
 
 RUN set -ex \
-    && apt-get update && apt-get install -y ca-certificates curl --no-install-recommends \
+    && apk add curl \
     && curl -L "https://github.com/gruntwork-io/terragrunt/releases/download/${TERRAGRUNT_VERSION}/terragrunt_${TARGETOS}_${TARGETARCH}" -o "terragrunt" \
     && chmod +x terragrunt \
     && mv terragrunt /usr/local/bin/
 
-FROM debian:${debian_version} AS awscli2-builder
+FROM alpine:${alpine_version}
 
 ARG AWSCLI_VERSION
-ARG TARGETOS
-ARG TARGETARCH
-
-RUN set -ex \
-    && apt-get update && apt-get install -y ca-certificates curl unzip --no-install-recommends \
-    && curl "https://awscli.amazonaws.com/awscli-exe-${TARGETOS}-$(echo $TARGETARCH | sed s/amd64/x86_64/ | sed s/arm64/aarch64/)-${AWSCLI_VERSION}.zip" -o "awscliv2.zip" \
-    && unzip awscliv2.zip \
-    # The --bin-dir is specified so that we can copy the entire bin directory
-    # from the installer stage into into /usr/local/bin of the final stage
-    # without accidentally copying over any other executables that may be
-    # present in /usr/local/bin of the installer stage.
-    && ./aws/install --bin-dir /aws-cli-bin/
-
-FROM debian:${debian_version}
-
 ENV TF_PLUGIN_CACHE_DIR=/tmp/terraform
 
 RUN set -ex \
     && deps=" \
         ca-certificates \
-        groff-base \
         less \
         git \
         openssh-client \
+        bash \
+        aws-cli \
         jq \
     " \
-    && apt-get update && apt-get install -y $deps --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/* \
+    && apk add $deps \
+    && rm -rf /var/cache/apk/* \
     && mkdir -p $TF_PLUGIN_CACHE_DIR
 
 # Install Terraform.
 COPY --from=terraform-builder /usr/local/bin/terraform /usr/local/bin/terraform
 # Install Terragrunt.
 COPY --from=terragrunt-builder /usr/local/bin/terragrunt /usr/local/bin/terragrunt
-# Install the AWS CLI version 2.
-COPY --from=awscli2-builder /usr/local/aws-cli/ /usr/local/aws-cli/
-COPY --from=awscli2-builder /aws-cli-bin/ /usr/local/bin/
 
 ENTRYPOINT ["/usr/local/bin/terraform"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,6 @@ RUN set -ex \
 
 FROM alpine:${ALPINE_VERSION}
 
-ENV TF_PLUGIN_CACHE_DIR=/root/.terraform.d/plugin-cache
-
 RUN set -ex \
     && deps=" \
         less \
@@ -59,8 +57,7 @@ RUN set -ex \
         groff \
     " \
     && apk add $deps \
-    && rm -rf /var/cache/apk/* \
-    && mkdir -p $TF_PLUGIN_CACHE_DIR
+    && rm -rf /var/cache/apk/*
 
 # Install Terraform.
 COPY --from=terraform-builder /usr/local/bin/terraform /usr/local/bin/terraform

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,6 @@ ENV TF_PLUGIN_CACHE_DIR=/root/.terraform.d/plugin-cache
 
 RUN set -ex \
     && deps=" \
-        ca-certificates \
         less \
         git \
         openssh-client \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ ARG TARGETARCH
 
 RUN set -ex \
     && apt-get update && apt-get install -y ca-certificates curl unzip --no-install-recommends \
-    && curl "https://awscli.amazonaws.com/awscli-exe-${TARGETOS}-$(echo $TARGETARCH | sed s/amd64/x86_64/)-${AWSCLI_VERSION}.zip" -o "awscliv2.zip" \
+    && curl "https://awscli.amazonaws.com/awscli-exe-${TARGETOS}-$(echo $TARGETARCH | sed s/amd64/x86_64/ | sed s/arm64/aarch64/)-${AWSCLI_VERSION}.zip" -o "awscliv2.zip" \
     && unzip awscliv2.zip \
     # The --bin-dir is specified so that we can copy the entire bin directory
     # from the installer stage into into /usr/local/bin of the final stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-ARG alpine_version=3.22
+ARG ALPINE_VERSION=3.22
 
 # We install each tool (e.g., Terraform, Terragrunt, and the AWS CLI) in a
 # separate build stage. This design allows us to install each tool in parallel
 # while preventing a change to one layer from blowing away the cache of
 # subsequent layers.
 # https://docs.docker.com/build/building/multi-stage/
-FROM alpine:${alpine_version} AS terraform-builder
+FROM alpine:${ALPINE_VERSION} AS terraform-builder
 
 # These args support multi-platform builds if we decide to produce a linux/arm64
 # variant.
@@ -20,7 +20,7 @@ RUN set -ex \
     && unzip terraform.zip \
     && mv terraform /usr/local/bin/
 
-FROM alpine:${alpine_version} AS terragrunt-builder
+FROM alpine:${ALPINE_VERSION} AS terragrunt-builder
 
 ARG TERRAGRUNT_VERSION
 ARG TARGETOS
@@ -32,7 +32,7 @@ RUN set -ex \
     && chmod +x terragrunt \
     && mv terragrunt /usr/local/bin/
 
-FROM alpine:${alpine_version} AS tflint-builder
+FROM alpine:${ALPINE_VERSION} AS tflint-builder
 
 ARG TFLINT_VERSION
 ARG TARGETOS
@@ -44,7 +44,7 @@ RUN set -ex \
     && unzip tflint.zip\
     && mv tflint /usr/local/bin/
 
-FROM alpine:${alpine_version}
+FROM alpine:${ALPINE_VERSION}
 
 ARG AWSCLI_VERSION
 ENV TF_PLUGIN_CACHE_DIR=/tmp/terraform

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ RUN set -ex \
         bash \
         aws-cli \
         jq \
+        groff \
     " \
     && apk add $deps \
     && rm -rf /var/cache/apk/* \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN set -ex \
 
 FROM alpine:${ALPINE_VERSION}
 
-ENV TF_PLUGIN_CACHE_DIR=/tmp/terraform
+ENV TF_PLUGIN_CACHE_DIR=/root/.terraform.d/plugin-cache
 
 RUN set -ex \
     && deps=" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ALPINE_VERSION=3.22
+ARG ALPINE_VERSION=latest
 
 # We install each tool (e.g., Terraform, Terragrunt, and the AWS CLI) in a
 # separate build stage. This design allows us to install each tool in parallel

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,18 @@
+ARG debian_version=bookworm-slim
+
 # We install each tool (e.g., Terraform, Terragrunt, and the AWS CLI) in a
 # separate build stage. This design allows us to install each tool in parallel
 # while preventing a change to one layer from blowing away the cache of
 # subsequent layers.
 # https://docs.docker.com/build/building/multi-stage/
-FROM debian:bookworm-slim AS terraform-builder
+FROM debian:${debian_version} AS terraform-builder
 
 # These args support multi-platform builds if we decide to produce a linux/arm64
 # variant.
 # https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/#93cb
+ARG TERRAFORM_VERSION
 ARG TARGETOS
 ARG TARGETARCH
-
-ENV TERRAFORM_VERSION="%%TERRAFORM_VERSION%%"
 
 RUN set -ex \
     && apt-get update && apt-get install -y ca-certificates curl unzip --no-install-recommends \
@@ -19,12 +20,11 @@ RUN set -ex \
     && unzip terraform.zip \
     && mv terraform /usr/local/bin/
 
-FROM debian:bookworm-slim AS terragrunt-builder
+FROM debian:${debian_version} AS terragrunt-builder
 
+ARG TERRAGRUNT_VERSION
 ARG TARGETOS
 ARG TARGETARCH
-
-ENV TERRAGRUNT_VERSION="%%TERRAGRUNT_VERSION%%"
 
 RUN set -ex \
     && apt-get update && apt-get install -y ca-certificates curl --no-install-recommends \
@@ -32,12 +32,11 @@ RUN set -ex \
     && chmod +x terragrunt \
     && mv terragrunt /usr/local/bin/
 
-FROM debian:bookworm-slim AS awscli2-builder
+FROM debian:${debian_version} AS awscli2-builder
 
+ARG AWSCLI_VERSION
 ARG TARGETOS
 ARG TARGETARCH
-
-ENV AWSCLI_VERSION="%%AWSCLI_VERSION%%"
 
 RUN set -ex \
     && apt-get update && apt-get install -y ca-certificates curl unzip --no-install-recommends \
@@ -49,7 +48,7 @@ RUN set -ex \
     # present in /usr/local/bin of the installer stage.
     && ./aws/install --bin-dir /aws-cli-bin/
 
-FROM debian:bookworm-slim
+FROM debian:${debian_version}
 
 ENV TF_PLUGIN_CACHE_DIR=/tmp/terraform
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,18 @@ RUN set -ex \
     && chmod +x terragrunt \
     && mv terragrunt /usr/local/bin/
 
+FROM alpine:${alpine_version} AS tflint-builder
+
+ARG TFLINT_VERSION
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN set -ex \
+    && apk add curl unzip \
+    && curl -L "https://github.com/terraform-linters/tflint/releases/download/${TFLINT_VERSION}/tflint_${TARGETOS}_${TARGETARCH}.zip" -o "tflint.zip" \
+    && unzip tflint.zip\
+    && mv tflint /usr/local/bin/
+
 FROM alpine:${alpine_version}
 
 ARG AWSCLI_VERSION
@@ -55,5 +67,7 @@ RUN set -ex \
 COPY --from=terraform-builder /usr/local/bin/terraform /usr/local/bin/terraform
 # Install Terragrunt.
 COPY --from=terragrunt-builder /usr/local/bin/terragrunt /usr/local/bin/terragrunt
+#Install TFLint
+COPY --from=tflint-builder /usr/local/bin/tflint /usr/local/bin/tflint
 
 ENTRYPOINT ["/usr/local/bin/terraform"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -71,4 +71,6 @@ COPY --from=terragrunt-builder /usr/local/bin/terragrunt /usr/local/bin/terragru
 COPY --from=awscli2-builder /usr/local/aws-cli/ /usr/local/aws-cli/
 COPY --from=awscli2-builder /aws-cli-bin/ /usr/local/bin/
 
+ENV TF_PLUGIN_CACHE_DIR=/tmp/terraform
+
 ENTRYPOINT ["/usr/local/bin/terraform"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -3,7 +3,7 @@
 # while preventing a change to one layer from blowing away the cache of
 # subsequent layers.
 # https://docs.docker.com/build/building/multi-stage/
-FROM debian:bullseye-slim AS terraform-builder
+FROM debian:bookworm-slim AS terraform-builder
 
 # These args support multi-platform builds if we decide to produce a linux/arm64
 # variant.
@@ -19,7 +19,7 @@ RUN set -ex \
     && unzip terraform.zip \
     && mv terraform /usr/local/bin/
 
-FROM debian:bullseye-slim AS terragrunt-builder
+FROM debian:bookworm-slim AS terragrunt-builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -32,7 +32,7 @@ RUN set -ex \
     && chmod +x terragrunt \
     && mv terragrunt /usr/local/bin/
 
-FROM debian:bullseye-slim AS awscli2-builder
+FROM debian:bookworm-slim AS awscli2-builder
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -49,7 +49,7 @@ RUN set -ex \
     # present in /usr/local/bin of the installer stage.
     && ./aws/install --bin-dir /aws-cli-bin/
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 RUN set -ex \
     && deps=" \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -51,6 +51,8 @@ RUN set -ex \
 
 FROM debian:bookworm-slim
 
+ENV TF_PLUGIN_CACHE_DIR=/tmp/terraform
+
 RUN set -ex \
     && deps=" \
         ca-certificates \
@@ -61,7 +63,8 @@ RUN set -ex \
         jq \
     " \
     && apt-get update && apt-get install -y $deps --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p $TF_PLUGIN_CACHE_DIR
 
 # Install Terraform.
 COPY --from=terraform-builder /usr/local/bin/terraform /usr/local/bin/terraform
@@ -70,7 +73,5 @@ COPY --from=terragrunt-builder /usr/local/bin/terragrunt /usr/local/bin/terragru
 # Install the AWS CLI version 2.
 COPY --from=awscli2-builder /usr/local/aws-cli/ /usr/local/aws-cli/
 COPY --from=awscli2-builder /aws-cli-bin/ /usr/local/bin/
-
-ENV TF_PLUGIN_CACHE_DIR=/tmp/terraform
 
 ENTRYPOINT ["/usr/local/bin/terraform"]

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ services:
     volumes:
       - .:/workspace
       - ~/.aws:/root/.aws:ro
-      - ~/.terraform.d/plugin-cache:/tmp/terraform
+      - ~/.terraform.d/plugin-cache:/root/.terraform.d/plugin-cache
     environment:
       - AWS_REGION
       - AWS_PROFILE

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# docker-terraform [![CI](https://github.com/foreflight/docker-terraform/workflows/CI/badge.svg?branch=master)](https://github.com/foreflight/docker-terraform/actions?query=workflow%3ACI)
+# docker-terraform 
+
+[![Build and Publish ForeFlight Terraform image](https://github.com/foreflight/docker-terraform/actions/workflows/continuous_integration.yml/badge.svg)](https://github.com/foreflight/docker-terraform/actions/workflows/continuous_integration.yml)
 
 This repository contains a templated `Dockerfile` for image variants designed to run deployments using Terraform, Terragrunt, and the AWS CLI.
 

--- a/README.md
+++ b/README.md
@@ -13,20 +13,24 @@ Via Docker Compose, which includes volumes for basic functionality:
 ```yml
 services:
   terraform:
-    image: ghcr.io/foreflight/terraform:1.3.5
+    image: ghcr.io/foreflight/terraform:1.12.2
     volumes:
-      - ./:/usr/local/src
-      - $HOME/.aws:/root/.aws:ro
+      - .:/workspace
+      - ~/.aws:/root/.aws:ro
+      - ~/.terraform.d/plugin-cache:/tmp/terraform
     environment:
+      - AWS_REGION
       - AWS_PROFILE
-    working_dir: /usr/local/src
+      - TF_LOG
+    tty: true
+    working_dir: /workspace
     entrypoint: bash
 ```
 
 ```console
 $ docker-compose run --rm terraform
 root@5e7b9d6614b0:/usr/local/src# terraform -version
-Terraform v1.3.5
+Terraform v1.12.2
 on linux_amd64
 ```
 
@@ -41,5 +45,5 @@ on linux_amd64
 An example of how to use `cibuild` to build and test an image:
 
 ```console
-$ CI=1 TERRAFORM_VERSION=1.3.5 TERRAGRUNT_VERSION=v0.40.0 AWSCLI_VERSION=2.9.0 ./scripts/cibuild
+$ CI=1 TERRAFORM_VERSION=1.12.2 TERRAGRUNT_VERSION=v0.83.2 AWSCLI_VERSION=2.27.5 ./scripts/cibuild
 ```

--- a/README.md
+++ b/README.md
@@ -45,5 +45,5 @@ on linux_amd64
 An example of how to use `cibuild` to build and test an image:
 
 ```console
-$ CI=1 TERRAFORM_VERSION=1.12.2 TERRAGRUNT_VERSION=v0.83.2 AWSCLI_VERSION=2.27.5 ./scripts/cibuild
+$ CI=1 TERRAFORM_VERSION=1.12.2 TERRAGRUNT_VERSION=v0.83.2 TFLINT_VERSION=v0.58.1 ./scripts/cibuild
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docker-terraform 
 
-[![Build and Publish ForeFlight Terraform image](https://github.com/foreflight/docker-terraform/actions/workflows/continuous_integration.yml/badge.svg)](https://github.com/foreflight/docker-terraform/actions/workflows/continuous_integration.yml)
+[![Build and Publish ForeFlight Terraform Image](https://github.com/foreflight/docker-terraform/actions/workflows/continuous_integration.yml/badge.svg)](https://github.com/foreflight/docker-terraform/actions/workflows/continuous_integration.yml)
 
 This repository contains a templated `Dockerfile` for image variants designed to run deployments using Terraform, Terragrunt, and the AWS CLI.
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ services:
       - AWS_REGION
       - AWS_PROFILE
       - TF_LOG
+      - TF_PLUGIN_CACHE_DIR=/root/.terraform.d/plugin-cache
     tty: true
     working_dir: /workspace
     entrypoint: bash

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 This repository contains a templated `Dockerfile` for image variants designed to run deployments using Terraform, Terragrunt, and the AWS CLI.
 
 - [Usage](#usage)
-  - [Authentication with AWS Vault](#authentication-with-aws-vault)
 - [Template Variables](#template-variables)
 - [Testing](#testing)
 
@@ -29,24 +28,6 @@ $ docker-compose run --rm terraform
 root@5e7b9d6614b0:/usr/local/src# terraform -version
 Terraform v1.3.5
 on linux_amd64
-```
-
-### Authentication with AWS Vault
-
-At ForeFlight, we use [AWS Vault](https://github.com/99designs/aws-vault) to log into our numerous AWS accounts via the [`AssumeRole`](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) API.
-
-By default, the AWS CLI looks for credentials [in multiple places](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-precedence), starting with credentials passed as CLI parameters and ending with credentials exposed by the instance metadata server. 
-AWS Vault has a [local implementation](https://github.com/99designs/aws-vault/blob/master/server/ec2server.go) of the [EC2 instance metadata server](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html). So, we can use AWS Vault's local instance metadata server to supply credentials to the AWS CLI without needing to mount or pass anything to the container image:
-
-```console
-$ aws-vault exec --server my-aws-profile
-$ docker-compose run --rm terraform
-root@59531b150efd:/usr/local/src# aws sts get-caller-identity
-{
-    "UserId": "AIDASAMPLEUSERID",
-    "Account": "123456789012",
-    "Arn": "arn:aws:iam::123456789012:user/DevAdmin"
-}
 ```
 
 ### Template Variables

--- a/README.md
+++ b/README.md
@@ -47,5 +47,5 @@ on linux_amd64
 An example of how to use `cibuild` to build and test an image:
 
 ```console
-$ CI=1 TERRAFORM_VERSION=1.12.2 TERRAGRUNT_VERSION=v0.83.2 TFLINT_VERSION=v0.58.1 ./scripts/cibuild
+$ CI=1 ALPINE_VERSION=3.22 TERRAFORM_VERSION=1.12.2 TERRAGRUNT_VERSION=v0.83.2 TFLINT_VERSION=v0.58.1 ./scripts/cibuild
 ```

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -23,6 +23,7 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
         # linux/amd64 and take things one step at a time.
         # See https://github.com/foreflight/docker-terraform/issues/6
         docker build \
+            --build-arg ALPINE_VERSION=${ALPINE_VERSION} \
             --build-arg TERRAFORM_VERSION=${TERRAFORM_VERSION} \
             --build-arg TERRAGRUNT_VERSION=${TERRAGRUNT_VERSION} \
             --build-arg TFLINT_VERSION=${TFLINT_VERSION} \

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -25,7 +25,6 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
         docker build \
             --build-arg TERRAFORM_VERSION=${TERRAFORM_VERSION} \
             --build-arg TERRAGRUNT_VERSION=${TERRAGRUNT_VERSION} \
-            --build-arg AWSCLI_VERSION=${AWSCLI_VERSION} \
             --platform "linux/amd64" \
             --tag "ghcr.io/foreflight/terraform:${TERRAFORM_VERSION}" .
 

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -21,6 +21,7 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     else
         # Although the Dockerfile supports linux/arm64 builds, stick to
         # linux/amd64 and take things one step at a time.
+        # See https://github.com/foreflight/docker-terraform/issues/6
         docker build \
             --build-arg TERRAFORM_VERSION=${TERRAFORM_VERSION} \
             --build-arg TERRAGRUNT_VERSION=${TERRAGRUNT_VERSION} \

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -25,6 +25,7 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
         docker build \
             --build-arg TERRAFORM_VERSION=${TERRAFORM_VERSION} \
             --build-arg TERRAGRUNT_VERSION=${TERRAGRUNT_VERSION} \
+            --build-arg TFLINT_VERSION=${TFLINT_VERSION} \
             --platform "linux/amd64" \
             --tag "ghcr.io/foreflight/terraform:${TERRAFORM_VERSION}" .
 

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -19,14 +19,12 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     if [[ "${1:-}" == "--help" ]]; then
         usage
     else
-        sed -e "s/%%TERRAFORM_VERSION%%/${TERRAFORM_VERSION}/" \
-            -e "s/%%TERRAGRUNT_VERSION%%/${TERRAGRUNT_VERSION}/" \
-            -e "s/%%AWSCLI_VERSION%%/${AWSCLI_VERSION}/" \
-            "Dockerfile.template" >Dockerfile
-
         # Although the Dockerfile supports linux/arm64 builds, stick to
         # linux/amd64 and take things one step at a time.
         docker build \
+            --build-arg TERRAFORM_VERSION=${TERRAFORM_VERSION} \
+            --build-arg TERRAGRUNT_VERSION=${TERRAGRUNT_VERSION} \
+            --build-arg AWSCLI_VERSION=${AWSCLI_VERSION} \
             --platform "linux/amd64" \
             --tag "ghcr.io/foreflight/terraform:${TERRAFORM_VERSION}" .
 

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -23,10 +23,10 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
         # linux/amd64 and take things one step at a time.
         # See https://github.com/foreflight/docker-terraform/issues/6
         docker build \
-            --build-arg ALPINE_VERSION=${ALPINE_VERSION} \
-            --build-arg TERRAFORM_VERSION=${TERRAFORM_VERSION} \
-            --build-arg TERRAGRUNT_VERSION=${TERRAGRUNT_VERSION} \
-            --build-arg TFLINT_VERSION=${TFLINT_VERSION} \
+            --build-arg "ALPINE_VERSION=${ALPINE_VERSION}" \
+            --build-arg "TERRAFORM_VERSION=${TERRAFORM_VERSION}" \
+            --build-arg "TERRAGRUNT_VERSION=${TERRAGRUNT_VERSION}" \
+            --build-arg "TFLINT_VERSION=${TFLINT_VERSION}" \
             --platform "linux/amd64" \
             --tag "ghcr.io/foreflight/terraform:${TERRAFORM_VERSION}" .
 

--- a/scripts/test
+++ b/scripts/test
@@ -34,5 +34,10 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
         docker \
             run --rm --entrypoint \
             aws "ghcr.io/foreflight/terraform:${TERRAFORM_VERSION}" --version
+
+        # Running 'aws help' invokes some other features in AWS-CLI which has other dependencies like 'groff'
+        docker \
+            run --rm --entrypoint \
+            aws "ghcr.io/foreflight/terraform:${TERRAFORM_VERSION}" help
     fi
 fi

--- a/scripts/test
+++ b/scripts/test
@@ -25,6 +25,10 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
 
         docker \
             run --rm --entrypoint \
+            tflint "ghcr.io/foreflight/terraform:${TERRAFORM_VERSION}" --version
+
+        docker \
+            run --rm --entrypoint \
             terragrunt "ghcr.io/foreflight/terraform:${TERRAFORM_VERSION}" --version
 
         docker \


### PR DESCRIPTION
This PR adds:
- Updated Terraform, Terragrunt and AWS-CLI to newest versions
- Add TFLint
- Remove aws-vault documentation
- Change base-image to alpine reducing image-size by ~200 MB
- Prepared Dockerfile for Multi-arch images